### PR TITLE
Fix origin reference in contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@ you to accept the CLA when you open your pull request.
 ```
 mkdir -p $GOPATH/src/connectrpc.com/grpchealth
 cd $GOPATH/src/connectrpc.com
-git clone git@github.com:connectrpc/grpchealth-go.git grpchealth
+git clone git@github.com:your_github_username/grpchealth-go.git grpchealth
 cd grpchealth
 git remote add upstream https://github.com/connectrpc/grpchealth-go.git
 git fetch upstream


### PR DESCRIPTION
After forking, the user should clone their fork rather than upstream.
