### PR TITLE
Update copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Buf Technologies, Inc.
+   Copyright 2022 The Connect Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ generate: $(BIN)/buf $(BIN)/protoc-gen-go $(BIN)/license-header ## Regenerate co
 	PATH=$(abspath $(BIN)) buf generate
 	license-header \
 		--license-type apache \
-		--copyright-holder "Buf Technologies, Inc." \
+		--copyright-holder "The Connect Authors" \
 		--year-range "$(COPYRIGHT_YEARS)" $(LICENSE_IGNORE)
 
 .PHONY: upgrade

--- a/grpchealth.go
+++ b/grpchealth.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/grpchealth_test.go
+++ b/grpchealth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/go/connectext/grpc/health/v1/health.pb.go
+++ b/internal/gen/go/connectext/grpc/health/v1/health.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update to use "The Connect Authors" instead of "Buf Technologies, Inc."