### PR TITLE
Update to go 1.21 and golangci to 1.60.0, test with go 1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -30,5 +30,5 @@ jobs:
       - name: Lint
         # Often, lint & gofmt guidelines depend on the Go version. To prevent
         # conflicting guidance, run only on the most recent supported version.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -29,33 +27,26 @@ linters:
   enable-all: true
   disable:
     - cyclop            # covered by gocyclo
-    - deadcode          # abandoned
     - depguard          # unnecessary for small libraries
-    - exhaustivestruct  # replaced by exhaustruct
+    - err113            # don't _always_ need to wrap errors
+    - execinquery       # deprecated in golangci 1.58.0
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
     - inamedparam       # convention is not followed
-    - interfacer        # deprecated by author
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
     - nlreturn          # generous whitespace violates house style
     - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
     - protogetter       # too many false positives
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
     - testpackage       # internal tests are fine
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,6 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
-    - err113            # don't _always_ need to wrap errors
     - execinquery       # deprecated in golangci 1.58.0
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
@@ -50,4 +49,4 @@ issues:
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
-    - "err113: do not define dynamic errors.*"
+    - "do not define dynamic errors.*"

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
 
 $(BIN)/protoc-gen-go: Makefile
 	@mkdir -p $(@D)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/grpchealth
 
-go 1.20
+go 1.21
 
 retract v1.1.1 // module cache poisoned, use v1.1.2
 

--- a/grpchealth_test.go
+++ b/grpchealth_test.go
@@ -83,7 +83,7 @@ func TestHealth(t *testing.T) {
 			connect.NewRequest(&healthv1.HealthCheckRequest{Service: service}),
 		)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 		if Status(res.Msg.Status) != expect {
 			t.Fatalf("got status %v, expected %v", res.Msg.Status, expect)
@@ -130,7 +130,7 @@ func TestHealth(t *testing.T) {
 		connect.NewRequest(&healthv1.HealthCheckRequest{Service: userFQN}),
 	)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	defer stream.Close()
 	if ok := stream.Receive(); ok {


### PR DESCRIPTION
Now that go 1.23 is out, we can update this repo to no longer support go 1.20.