### PR TITLE
Use semantic names in CI jobs instead of numbers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,15 @@ permissions:
   contents: read
 jobs:
   ci:
+    name: ci (go:${{ matrix.go-version.name }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x]
+      go-version:
+      - name: latest
+        version: 1.24.x
+      - name: previous
+        version: 1.23.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -24,11 +29,11 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ matrix.go-version.version }}
       - name: Test
         run: make test
       - name: Lint
         # Often, lint & gofmt guidelines depend on the Go version. To prevent
         # conflicting guidance, run only on the most recent supported version.
-        if: matrix.go-version == '1.24.x'
+        if: matrix.go-version.name == 'latest'
         run: make checkgenerate && make lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-      go-version:
-      - name: latest
-        version: 1.24.x
-      - name: previous
-        version: 1.23.x
+        go-version:
+        - name: latest
+          version: 1.24.x
+        - name: previous
+          version: 1.23.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ func main() {
 
 This module is stable. It supports:
 
-* The three most recent major releases of Go. Keep in mind that [only the last
-  two releases receive security patches][go-support-policy].
+* The two most recent major releases of Go (the same version of Go that continue to
+  [eceive security patches][go-support-policy]).
 * [APIv2] of Protocol Buffers in Go (`google.golang.org/protobuf`).
 
 Within those parameters, `grpchealth` follows semantic versioning.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/grpchealth
 
-go 1.23
+go 1.23.0
 
 retract v1.1.1 // module cache poisoned, use v1.1.2
 


### PR DESCRIPTION
This also updates the README to describe the recent changes to Go version support. And it tweaks the minimum Go version in `go.mod` to reference a valid toolchain instead of just a language level (for consistency with connect-go repo).