### PR TITLE
Fix example in README to use standard net/http h2c support

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,7 @@ changelog:
       - ignore-for-release
     authors:
       - dependabot
+      - dependabot[bot]
   categories:
     - title: Enhancements
       labels:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
           version: 1.24.x
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Install Go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         go-version:
         - name: latest
-          version: 1.24.x
+          version: 1.25.x
         - name: previous
-          version: 1.23.x
+          version: 1.24.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,10 +12,12 @@ linters:
     - maintidx          # covered by gocyclo
     - mnd               # some unnamed constants are okay
     - nlreturn          # generous whitespace violates house style
+    - noinlineerr       # inline error handling is fine
     - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
     - testpackage       # internal tests are fine
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
+    - wsl_v5            # generous whitespace violates house style
   settings:
     errcheck:
       check-type-assertions: true

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
 
 $(BIN)/protoc-gen-go: Makefile
 	@mkdir -p $(@D)

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ package main
 import (
   "net/http"
 
-  "golang.org/x/net/http2"
-  "golang.org/x/net/http2/h2c"
   "connectrpc.com/grpchealth"
 )
 
@@ -41,12 +39,17 @@ func main() {
     // reference userv1.UserServiceName and groupv1.GroupServiceName.
   )
   mux.Handle(grpchealth.NewHandler(checker))
-  // If you don't need to support HTTP/2 without TLS (h2c), you can drop
-  // x/net/http2 and use http.ListenAndServeTLS instead.
-  http.ListenAndServe(
-    ":8080",
-    h2c.NewHandler(mux, &http2.Server{}),
-  )
+  // If you don't need to support HTTP/2 without TLS (h2c), you can use
+  // http.ListenAndServeTLS instead.
+  protocols := new(http.Protocols)
+  protocols.SetHTTP1(true)
+  protocols.SetUnencryptedHTTP2(true)
+  server := &http.Server{
+    Addr:      ":8080",
+    Handler:   mux,
+    Protocols: protocols,
+  }
+  server.ListenAndServe()
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module connectrpc.com/grpchealth
 
-go 1.23.0
+go 1.24.0
 
 retract v1.1.1 // module cache poisoned, use v1.1.2
 

--- a/grpchealth_test.go
+++ b/grpchealth_test.go
@@ -15,7 +15,6 @@
 package grpchealth
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -79,7 +78,7 @@ func TestHealth(t *testing.T) {
 	) {
 		t.Helper()
 		res, err := client.CallUnary(
-			context.Background(),
+			t.Context(),
 			connect.NewRequest(&healthv1.HealthCheckRequest{Service: service}),
 		)
 		if err != nil {
@@ -95,7 +94,7 @@ func TestHealth(t *testing.T) {
 	) {
 		t.Helper()
 		_, err := client.CallUnary(
-			context.Background(),
+			t.Context(),
 			connect.NewRequest(&healthv1.HealthCheckRequest{Service: service}),
 		)
 		if err == nil {
@@ -130,7 +129,7 @@ func TestHealth(t *testing.T) {
 		connect.WithGRPC(),
 	)
 	stream, err := watcher.CallServerStream(
-		context.Background(),
+		t.Context(),
 		connect.NewRequest(&healthv1.HealthCheckRequest{Service: userFQN}),
 	)
 	if err != nil {
@@ -145,7 +144,7 @@ func TestHealth(t *testing.T) {
 	}
 	var connectErr *connect.Error
 	if ok := errors.As(stream.Err(), &connectErr); !ok {
-		t.Fatalf("got %v (%T), expected a *connect.Error", err, err)
+		t.Fatalf("got %v (%T), expected a *connect.Error", stream.Err(), stream.Err())
 	}
 	if code := connectErr.Code(); code != connect.CodeUnimplemented {
 		t.Fatalf("got code %v, expected CodeUnimplemented", code)


### PR DESCRIPTION
Noticed that the example still showed the use of h2c prior to it being supported in Go 1.24. Update the Go version from 1.23 to 1.24 (matching the versions currently used by connect-go).