### PR TITLE
Add Watcher interface and Watch RPC support

### DIFF
--- a/grpchealth.go
+++ b/grpchealth.go
@@ -30,14 +30,18 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sync"
 
 	"connectrpc.com/connect"
 	healthv1 "connectrpc.com/grpchealth/internal/gen/go/connectext/grpc/health/v1"
 )
 
-// HealthV1ServiceName is the fully-qualified name of the v1 version of the health service.
-const HealthV1ServiceName = "grpc.health.v1.Health"
+const (
+	// HealthV1ServiceName is the fully-qualified name of the v1 version of the health service.
+	HealthV1ServiceName = "grpc.health.v1.Health"
+
+	checkProcedure = "/" + HealthV1ServiceName + "/Check"
+	watchProcedure = "/" + HealthV1ServiceName + "/Watch"
+)
 
 // Status describes the health of a service.
 type Status uint8
@@ -73,52 +77,30 @@ func (s Status) String() string {
 // health-checking API. It returns the path on which to mount the handler and
 // the HTTP handler itself.
 //
-// Note that the returned handler only supports the unary Check method, not the
-// streaming Watch. As suggested in gRPC's health schema, it returns
-// connect.CodeUnimplemented for the Watch method.
+// If the Checker also implements [Watcher], the returned handler supports the
+// streaming Watch RPC. Otherwise, the Watch method returns
+// connect.CodeUnimplemented.
 //
 // For more details on gRPC's health checking protocol, see
 // https://github.com/grpc/grpc/blob/master/doc/health-checking.md and
 // https://github.com/grpc/grpc/blob/master/src/proto/grpc/health/v1/health.proto.
 func NewHandler(checker Checker, options ...connect.HandlerOption) (string, http.Handler) {
-	const serviceName = "/grpc.health.v1.Health/"
+	const serviceName = "/" + HealthV1ServiceName + "/"
+	hdlr := &handler{checker: checker}
+	if watcher, ok := checker.(Watcher); ok {
+		hdlr.watcher = watcher
+	}
 	mux := http.NewServeMux()
-	check := connect.NewUnaryHandler(
-		serviceName+"Check",
-		func(
-			ctx context.Context,
-			req *connect.Request[healthv1.HealthCheckRequest],
-		) (*connect.Response[healthv1.HealthCheckResponse], error) {
-			var checkRequest CheckRequest
-			if req.Msg != nil {
-				checkRequest.Service = req.Msg.GetService()
-			}
-			checkResponse, err := checker.Check(ctx, &checkRequest)
-			if err != nil {
-				return nil, err
-			}
-			return connect.NewResponse(&healthv1.HealthCheckResponse{
-				Status: healthv1.HealthCheckResponse_ServingStatus(checkResponse.Status),
-			}), nil
-		},
+	mux.Handle(checkProcedure, connect.NewUnaryHandler(
+		checkProcedure,
+		hdlr.check,
 		options...,
-	)
-	mux.Handle(serviceName+"Check", check)
-	watch := connect.NewServerStreamHandler(
-		serviceName+"Watch",
-		func(
-			_ context.Context,
-			_ *connect.Request[healthv1.HealthCheckRequest],
-			_ *connect.ServerStream[healthv1.HealthCheckResponse],
-		) error {
-			return connect.NewError(
-				connect.CodeUnimplemented,
-				errors.New("connect doesn't support watching health state"),
-			)
-		},
+	))
+	mux.Handle(watchProcedure, connect.NewServerStreamHandler(
+		watchProcedure,
+		hdlr.watch,
 		options...,
-	)
-	mux.Handle(serviceName+"Watch", watch)
+	))
 	return serviceName, mux
 }
 
@@ -148,57 +130,105 @@ type Checker interface {
 	Check(context.Context, *CheckRequest) (*CheckResponse, error)
 }
 
-// StaticChecker is a simple Checker implementation. It always returns
-// StatusServing for the process, and it returns a static value for each
-// service.
-//
-// If you have a dynamic list of services, want to ping a database as part of
-// your health check, or otherwise need something more specialized, you should
-// write a custom Checker implementation.
-type StaticChecker struct {
-	mu       sync.RWMutex
-	statuses map[string]Status
+// A Watcher extends Checker with the ability to notify the caller when the
+// health status of a service changes. When a Checker also implements Watcher,
+// the handler returned by [NewHandler] supports the streaming Watch RPC.
+type Watcher interface {
+	Checker
+
+	// Watch monitors the health of the requested service and calls onChange
+	// whenever the status may have changed. Implementations should return
+	// quickly rather than blocking. They may return an error if the request
+	// cannot be satisfied (for example, if the service is unknown). The
+	// context is only used for the duration of the Watch call itself; it
+	// does not govern the lifetime of the watch.
+	//
+	// The returned stop function tells the implementation to stop calling
+	// onChange. However, if two goroutines are racing, one calling stop and
+	// the other calling onChange, this is fine. In other words, it is not
+	// an error if onChange gets called after stop; but stop should arrange
+	// for calls to onChange to cease.
+	Watch(ctx context.Context, req *CheckRequest, onChange func()) (stop func(), err error)
 }
 
-// NewStaticChecker constructs a StaticChecker. By default, each of the
-// supplied services has StatusServing.
-//
-// The supplied strings should be fully-qualified protobuf service names (for
-// example, "acme.user.v1.UserService"). Generated Connect service files
-// have this declared as a constant.
-func NewStaticChecker(services ...string) *StaticChecker {
-	statuses := make(map[string]Status, len(services))
-	for _, service := range services {
-		statuses[service] = StatusServing
-	}
-	return &StaticChecker{statuses: statuses}
+type handler struct {
+	checker Checker
+	watcher Watcher // nil if checker does not implement Watcher
 }
 
-// SetStatus sets the health status of a service, registering a new service if
-// necessary. It's safe to call SetStatus and Check concurrently.
-//
-// If the given service name is empty, it sets a server-wide status that is
-// returned to check requests that do not request a particular service. If no
-// such status is ever set, checks that do not request a particular service
-// will get a response of StatusServing.
-func (c *StaticChecker) SetStatus(service string, status Status) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.statuses[service] = status
+func (h *handler) check(
+	ctx context.Context,
+	req *connect.Request[healthv1.HealthCheckRequest],
+) (*connect.Response[healthv1.HealthCheckResponse], error) {
+	var checkRequest CheckRequest
+	if req.Msg != nil {
+		checkRequest.Service = req.Msg.GetService()
+	}
+	checkResponse, err := h.checker.Check(ctx, &checkRequest)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&healthv1.HealthCheckResponse{
+		Status: healthv1.HealthCheckResponse_ServingStatus(checkResponse.Status),
+	}), nil
 }
 
-// Check implements Checker. It's safe to call concurrently with SetStatus.
-func (c *StaticChecker) Check(_ context.Context, req *CheckRequest) (*CheckResponse, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if status, registered := c.statuses[req.Service]; registered {
-		return &CheckResponse{Status: status}, nil
+func (h *handler) watch(
+	ctx context.Context,
+	req *connect.Request[healthv1.HealthCheckRequest],
+	stream *connect.ServerStream[healthv1.HealthCheckResponse],
+) error {
+	if h.watcher == nil {
+		return connect.NewError(
+			connect.CodeUnimplemented,
+			errors.New("watching health state is not supported"),
+		)
 	}
-	if req.Service == "" {
-		return &CheckResponse{Status: StatusServing}, nil
+	var checkRequest CheckRequest
+	checkRequest.Service = req.Msg.GetService()
+	changed := make(chan struct{}, 1)
+	stop, err := h.watcher.Watch(ctx, &checkRequest, func() {
+		select {
+		case changed <- struct{}{}:
+		default:
+		}
+	})
+	if err != nil {
+		return err
 	}
-	return nil, connect.NewError(
-		connect.CodeNotFound,
-		fmt.Errorf("unknown service %s", req.Service),
-	)
+	defer stop()
+	// Send the current status immediately.
+	var lastStatus healthv1.HealthCheckResponse_ServingStatus
+	if err := h.checkAndSend(ctx, &checkRequest, stream, &lastStatus, true); err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-changed:
+			if err := h.checkAndSend(ctx, &checkRequest, stream, &lastStatus, false); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (h *handler) checkAndSend(
+	ctx context.Context,
+	req *CheckRequest,
+	stream *connect.ServerStream[healthv1.HealthCheckResponse],
+	lastStatus *healthv1.HealthCheckResponse_ServingStatus,
+	forceSend bool,
+) error {
+	checkResponse, err := h.checker.Check(ctx, req)
+	if err != nil {
+		return err
+	}
+	status := healthv1.HealthCheckResponse_ServingStatus(checkResponse.Status)
+	if status == *lastStatus && !forceSend {
+		return nil
+	}
+	*lastStatus = status
+	return stream.Send(&healthv1.HealthCheckResponse{Status: status})
 }

--- a/grpchealth_test.go
+++ b/grpchealth_test.go
@@ -15,6 +15,7 @@
 package grpchealth
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -51,7 +52,7 @@ func TestCode(t *testing.T) {
 	}
 }
 
-func TestHealth(t *testing.T) {
+func TestHealth_Check(t *testing.T) {
 	const (
 		userFQN = "acme.user.v1.UserService"
 		unknown = "foobar"
@@ -67,7 +68,7 @@ func TestHealth(t *testing.T) {
 
 	client := connect.NewClient[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse](
 		server.Client(),
-		server.URL+"/grpc.health.v1.Health/Check",
+		server.URL+checkProcedure,
 		connect.WithGRPC(),
 	)
 
@@ -122,15 +123,129 @@ func TestHealth(t *testing.T) {
 	assertUnknown(t, unknown)
 	checker.SetStatus(unknown, StatusServing)
 	assertStatus(t, unknown, StatusServing)
+}
 
-	watcher := connect.NewClient[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse](
+func TestHealth_Watch(t *testing.T) {
+	const (
+		userFQN = "acme.user.v1.UserService"
+		pingFQN = "acme.ping.v1.PingService"
+	)
+	t.Parallel()
+	checker := NewStaticChecker(userFQN, pingFQN)
+	mux := http.NewServeMux()
+	mux.Handle(NewHandler(checker))
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	watchClient := connect.NewClient[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse](
 		server.Client(),
-		server.URL+"/grpc.health.v1.Health/Watch",
+		server.URL+watchProcedure,
 		connect.WithGRPC(),
 	)
-	stream, err := watcher.CallServerStream(
+	openStream := func(ctx context.Context, service string) *connect.ServerStreamForClient[healthv1.HealthCheckResponse] {
+		t.Helper()
+		stream, err := watchClient.CallServerStream(
+			ctx,
+			connect.NewRequest(&healthv1.HealthCheckRequest{Service: service}),
+		)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		return stream
+	}
+	receiveStatus := func(t *testing.T, stream *connect.ServerStreamForClient[healthv1.HealthCheckResponse], expect Status) {
+		t.Helper()
+		if ok := stream.Receive(); !ok {
+			t.Fatalf("expected message from Watch, got error: %v", stream.Err())
+		}
+		if got := Status(stream.Msg().GetStatus()); got != expect { //nolint:gosec
+			t.Fatalf("got status %v, expected %v", got, expect)
+		}
+	}
+
+	// Watching an unknown service should return CodeNotFound.
+	unknownStream := openStream(t.Context(), "unknown.Service")
+	defer unknownStream.Close()
+	if ok := unknownStream.Receive(); ok {
+		t.Fatal("expected error from Watch on unknown service, got message")
+	}
+	var connectErr *connect.Error
+	if !errors.As(unknownStream.Err(), &connectErr) {
+		t.Fatalf("got %v (%T), expected a *connect.Error", unknownStream.Err(), unknownStream.Err())
+	}
+	if code := connectErr.Code(); code != connect.CodeNotFound {
+		t.Fatalf("got code %v, expected CodeNotFound", code)
+	}
+
+	// Open three streams: two named services and the process-wide
+	// empty string. The empty string has no registered status, but
+	// should still succeed since it represents overall process health.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	userStream := openStream(ctx, userFQN)
+	defer userStream.Close()
+	pingStream := openStream(ctx, pingFQN)
+	defer pingStream.Close()
+	processStream := openStream(ctx, "")
+	defer processStream.Close()
+
+	// All three should receive their current status immediately.
+	receiveStatus(t, userStream, StatusServing)
+	receiveStatus(t, pingStream, StatusServing)
+	receiveStatus(t, processStream, StatusServing)
+
+	// Changing one service should only notify that service's stream.
+	// If a spurious message were sent to another stream, it would
+	// cause a later receive on that stream to return the wrong status.
+	checker.SetStatus(userFQN, StatusNotServing)
+	receiveStatus(t, userStream, StatusNotServing)
+
+	checker.SetStatus(pingFQN, StatusNotServing)
+	receiveStatus(t, pingStream, StatusNotServing)
+
+	// The process-wide stream should respond to SetStatus("").
+	checker.SetStatus("", StatusNotServing)
+	receiveStatus(t, processStream, StatusNotServing)
+
+	// De-duplication: setting the same status should not produce a
+	// message. Set the same, then a different status, and verify we
+	// only receive the different one.
+	checker.SetStatus(userFQN, StatusNotServing)
+	checker.SetStatus(userFQN, StatusServing)
+	receiveStatus(t, userStream, StatusServing)
+
+	// Cancel the context and verify the streams end.
+	cancel()
+	for userStream.Receive() {
+	}
+	for pingStream.Receive() {
+	}
+	for processStream.Receive() {
+	}
+}
+
+func TestWatchUnimplemented(t *testing.T) {
+	t.Parallel()
+	checker := checkerFunc(func(_ context.Context, _ *CheckRequest) (*CheckResponse, error) {
+		return &CheckResponse{Status: StatusServing}, nil
+	})
+	mux := http.NewServeMux()
+	mux.Handle(NewHandler(checker))
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	watchClient := connect.NewClient[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse](
+		server.Client(),
+		server.URL+watchProcedure,
+		connect.WithGRPC(),
+	)
+	stream, err := watchClient.CallServerStream(
 		t.Context(),
-		connect.NewRequest(&healthv1.HealthCheckRequest{Service: userFQN}),
+		connect.NewRequest(&healthv1.HealthCheckRequest{Service: "anything"}),
 	)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -149,4 +264,11 @@ func TestHealth(t *testing.T) {
 	if code := connectErr.Code(); code != connect.CodeUnimplemented {
 		t.Fatalf("got code %v, expected CodeUnimplemented", code)
 	}
+}
+
+// checkerFunc is a Checker that does not implement Watcher.
+type checkerFunc func(context.Context, *CheckRequest) (*CheckResponse, error)
+
+func (f checkerFunc) Check(ctx context.Context, req *CheckRequest) (*CheckResponse, error) {
+	return f(ctx, req)
 }

--- a/static_checker.go
+++ b/static_checker.go
@@ -1,0 +1,128 @@
+// Copyright 2022-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpchealth
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"connectrpc.com/connect"
+)
+
+// StaticChecker is a simple Checker implementation. It always returns
+// StatusServing for the process, and it returns a static value for each
+// service. It also implements [Watcher], so the handler returned by
+// [NewHandler] supports the streaming Watch RPC.
+//
+// If you have a dynamic list of services, want to ping a database as part of
+// your health check, or otherwise need something more specialized, you should
+// write a custom Checker implementation.
+type StaticChecker struct {
+	mu       sync.RWMutex
+	statuses map[string]Status
+	watchers map[string][]*staticWatchEntry
+}
+
+type staticWatchEntry struct {
+	onChange func()
+}
+
+// NewStaticChecker constructs a StaticChecker. By default, each of the
+// supplied services has StatusServing.
+//
+// The supplied strings should be fully-qualified protobuf service names (for
+// example, "acme.user.v1.UserService"). Generated Connect service files
+// have this declared as a constant.
+func NewStaticChecker(services ...string) *StaticChecker {
+	statuses := make(map[string]Status, len(services))
+	for _, service := range services {
+		statuses[service] = StatusServing
+	}
+	return &StaticChecker{statuses: statuses}
+}
+
+// SetStatus sets the health status of a service, registering a new service if
+// necessary. It's safe to call SetStatus and Check concurrently.
+//
+// If the given service name is empty, it sets a server-wide status that is
+// returned to check requests that do not request a particular service. If no
+// such status is ever set, checks that do not request a particular service
+// will get a response of StatusServing.
+func (c *StaticChecker) SetStatus(service string, status Status) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.statuses[service] = status
+	for _, entry := range c.watchers[service] {
+		// The onChange function is quick and non-blocking, so
+		// it is permissible to call it while holding c.mu.
+		entry.onChange()
+	}
+}
+
+// Check implements Checker. It's safe to call concurrently with SetStatus.
+func (c *StaticChecker) Check(_ context.Context, req *CheckRequest) (*CheckResponse, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if status, registered := c.statuses[req.Service]; registered {
+		return &CheckResponse{Status: status}, nil
+	}
+	if req.Service == "" {
+		return &CheckResponse{Status: StatusServing}, nil
+	}
+	return nil, connect.NewError(
+		connect.CodeNotFound,
+		fmt.Errorf("unknown service %s", req.Service),
+	)
+}
+
+// Watch implements Watcher. It's safe to call concurrently with SetStatus.
+func (c *StaticChecker) Watch(_ context.Context, req *CheckRequest, onChange func()) (func(), error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.watchers == nil {
+		c.watchers = make(map[string][]*staticWatchEntry)
+	}
+	if _, registered := c.statuses[req.Service]; !registered && req.Service != "" {
+		return nil, connect.NewError(
+			connect.CodeNotFound,
+			fmt.Errorf("unknown service %s", req.Service),
+		)
+	}
+	entry := &staticWatchEntry{
+		onChange: onChange,
+	}
+	c.watchers[req.Service] = append(c.watchers[req.Service], entry)
+	return func() {
+		c.removeWatcher(req.Service, entry)
+	}, nil
+}
+
+func (c *StaticChecker) removeWatcher(service string, entry *staticWatchEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entries := c.watchers[service]
+	for i, e := range entries {
+		if e != entry {
+			continue
+		}
+		// Found it.
+		c.watchers[service] = append(entries[:i], entries[i+1:]...)
+		if len(c.watchers[service]) == 0 {
+			delete(c.watchers, service)
+		}
+		return
+	}
+}


### PR DESCRIPTION
Introduce a `Watcher` interface that extends `Checker` with a `Watch` method for streaming health status changes. When the `Checker` passed to `NewHandler` implements `Watcher`, the handler supports the gRPC Watch RPC. `StaticChecker` now implements `Watcher` and has been moved to a separate file.

Resolves #81.