### PR TITLE
Add grpchealth client

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,114 @@
+// Copyright 2022-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpchealth
+
+import (
+	"context"
+	"iter"
+	"strings"
+
+	"connectrpc.com/connect"
+	healthv1 "connectrpc.com/grpchealth/internal/gen/go/connectext/grpc/health/v1"
+)
+
+// Compile-time assertion: *Client implements Checker.
+var _ Checker = (*Client)(nil)
+
+// Client calls the gRPC health-checking API. It implements [Checker], so it
+// can be used anywhere a Checker is expected. It is safe to use concurrently.
+type Client struct {
+	check *connect.Client[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse]
+	watch *connect.Client[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse]
+}
+
+// NewClient constructs a new Client for the gRPC health-checking API.
+//
+// The URL supplied should be the base URL of the Connect or gRPC server (for
+// example, https://api.example.com). By default the client uses the Connect
+// protocol with the binary Protobuf codec. To use the gRPC protocol, supply
+// [connect.WithGRPC] as an option.
+func NewClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) *Client {
+	baseURL = strings.TrimRight(baseURL, "/")
+	return &Client{
+		check: connect.NewClient[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse](
+			httpClient,
+			baseURL+checkProcedure,
+			opts...,
+		),
+		watch: connect.NewClient[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse](
+			httpClient,
+			baseURL+watchProcedure,
+			opts...,
+		),
+	}
+}
+
+// Check reports the health of the named service. An empty service name
+// requests the health of the whole server process. If the service is unknown,
+// the returned error will have [connect.CodeNotFound].
+func (c *Client) Check(ctx context.Context, req *CheckRequest) (*CheckResponse, error) {
+	res, err := c.check.CallUnary(ctx, connect.NewRequest(&healthv1.HealthCheckRequest{
+		Service: req.Service,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return &CheckResponse{
+		Status: Status(res.Msg.GetStatus()), //nolint:gosec // Conversion is safe; Status and ServingStatus share the same value space.
+	}, nil
+}
+
+// Watch returns an iterator over health status changes for the requested
+// service, and a stop function that cancels the underlying stream. The
+// iterator yields a [*CheckResponse] and an error for each received message.
+// When an error is yielded, it is the final value; the iterator terminates
+// immediately after.
+//
+// Callers must defer the stop function to release the stream resources:
+//
+//	watchIter, stop := client.Watch(ctx, &CheckRequest{Service: svc})
+//	defer stop()
+//	for resp, err := range watchIter {
+//	    if err != nil {
+//	        // Handle error; this is the last iteration.
+//	        break
+//	    }
+//	    fmt.Println(resp.Status)
+//	}
+func (c *Client) Watch(ctx context.Context, req *CheckRequest) (seq iter.Seq2[*CheckResponse, error], stop func()) {
+	ctx, cancel := context.WithCancel(ctx)
+	return func(yield func(*CheckResponse, error) bool) {
+		defer cancel()
+		stream, err := c.watch.CallServerStream(ctx, connect.NewRequest(&healthv1.HealthCheckRequest{
+			Service: req.Service,
+		}))
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		defer stream.Close()
+		for stream.Receive() {
+			resp := &CheckResponse{
+				Status: Status(stream.Msg().GetStatus()), //nolint:gosec // Conversion is safe; Status and ServingStatus share the same value space.
+			}
+			if !yield(resp, nil) {
+				return
+			}
+		}
+		if err := stream.Err(); err != nil {
+			yield(nil, err)
+		}
+	}, cancel
+}

--- a/client.go
+++ b/client.go
@@ -16,7 +16,6 @@ package grpchealth
 
 import (
 	"context"
-	"iter"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -70,32 +69,49 @@ func (c *Client) Check(ctx context.Context, req *CheckRequest) (*CheckResponse, 
 	}, nil
 }
 
-// Watch returns an iterator over health status changes for the requested
-// service, and a stop function that cancels the underlying stream. The
-// iterator yields a [*CheckResponse] and an error for each received message.
-// When an error is yielded, it is the final value; the iterator terminates
-// immediately after.
+// WatchEvent is a single update delivered by [Client.Watch]. Exactly one of
+// Response or Err is set. An Err event, when delivered, is the final event on
+// the channel.
+type WatchEvent struct {
+	Response *CheckResponse
+	Err      error
+}
+
+// Watch streams health status changes for the requested service. Status
+// updates are delivered on the returned channel. The channel closes when the
+// stream ends, either because ctx is canceled, the server terminates the
+// stream, or an error occurs. If the stream terminates with an error and ctx
+// has not been canceled, the final value on the channel has its Err field
+// set.
 //
-// Callers must defer the stop function to release the stream resources:
+// Callers cancel ctx to stop the stream and release resources:
 //
-//	watchIter, stop := client.Watch(ctx, &CheckRequest{Service: svc})
-//	defer stop()
-//	for resp, err := range watchIter {
-//	    if err != nil {
-//	        // Handle error; this is the last iteration.
+//	ctx, cancel := context.WithCancel(ctx)
+//	defer cancel()
+//	for event := range client.Watch(ctx, &CheckRequest{Service: svc}) {
+//	    if event.Err != nil {
+//	        // Handle error; this is the final event.
 //	        break
 //	    }
-//	    fmt.Println(resp.Status)
+//	    fmt.Println(event.Response.Status)
 //	}
-func (c *Client) Watch(ctx context.Context, req *CheckRequest) (seq iter.Seq2[*CheckResponse, error], stop func()) {
-	ctx, cancel := context.WithCancel(ctx)
-	return func(yield func(*CheckResponse, error) bool) {
-		defer cancel()
+func (c *Client) Watch(ctx context.Context, req *CheckRequest) <-chan WatchEvent {
+	events := make(chan WatchEvent)
+	go func() {
+		defer close(events)
+		send := func(event WatchEvent) bool {
+			select {
+			case <-ctx.Done():
+				return false
+			case events <- event:
+				return true
+			}
+		}
 		stream, err := c.watch.CallServerStream(ctx, connect.NewRequest(&healthv1.HealthCheckRequest{
 			Service: req.Service,
 		}))
 		if err != nil {
-			yield(nil, err)
+			send(WatchEvent{Err: err})
 			return
 		}
 		defer stream.Close()
@@ -103,12 +119,13 @@ func (c *Client) Watch(ctx context.Context, req *CheckRequest) (seq iter.Seq2[*C
 			resp := &CheckResponse{
 				Status: Status(stream.Msg().GetStatus()), //nolint:gosec // Conversion is safe; Status and ServingStatus share the same value space.
 			}
-			if !yield(resp, nil) {
+			if !send(WatchEvent{Response: resp}) {
 				return
 			}
 		}
 		if err := stream.Err(); err != nil {
-			yield(nil, err)
+			send(WatchEvent{Err: err})
 		}
-	}, cancel
+	}()
+	return events
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,160 @@
+// Copyright 2022-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpchealth
+
+import (
+	"errors"
+	"iter"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+)
+
+func TestClient_Check(t *testing.T) {
+	const (
+		userFQN = "acme.user.v1.UserService"
+		unknown = "foobar"
+	)
+	t.Parallel()
+	checker := NewStaticChecker(userFQN)
+	mux := http.NewServeMux()
+	mux.Handle(NewHandler(checker))
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.Client(), server.URL, connect.WithGRPC())
+
+	assertStatus := func(t *testing.T, service string, expect Status) {
+		t.Helper()
+		resp, err := client.Check(t.Context(), &CheckRequest{Service: service})
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if resp.Status != expect {
+			t.Fatalf("got status %v, expected %v", resp.Status, expect)
+		}
+	}
+
+	// Process-wide health.
+	assertStatus(t, "", StatusServing)
+	checker.SetStatus("", StatusNotServing)
+	assertStatus(t, "", StatusNotServing)
+	checker.SetStatus("", StatusServing)
+	assertStatus(t, "", StatusServing)
+
+	// Named service.
+	assertStatus(t, userFQN, StatusServing)
+	checker.SetStatus(userFQN, StatusNotServing)
+	assertStatus(t, userFQN, StatusNotServing)
+
+	// Unknown service returns CodeNotFound.
+	_, err := client.Check(t.Context(), &CheckRequest{Service: unknown})
+	if err == nil {
+		t.Fatalf("expected error checking unknown service %q", unknown)
+	}
+	var connectErr *connect.Error
+	if !errors.As(err, &connectErr) {
+		t.Fatalf("got %v (%T), expected a *connect.Error", err, err)
+	}
+	if code := connectErr.Code(); code != connect.CodeNotFound {
+		t.Fatalf("got code %v, expected CodeNotFound", code)
+	}
+}
+
+func TestClient_Watch(t *testing.T) {
+	const userFQN = "acme.user.v1.UserService"
+	t.Parallel()
+	checker := NewStaticChecker(userFQN)
+	mux := http.NewServeMux()
+	mux.Handle(NewHandler(checker))
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.Client(), server.URL, connect.WithGRPC())
+
+	// Use iter.Pull2 to step through the Watch iterator, so we can
+	// interleave SetStatus calls between receives.
+	watchIter, stop := client.Watch(t.Context(), &CheckRequest{Service: userFQN})
+	defer stop()
+	next, pullStop := iter.Pull2(watchIter)
+	defer pullStop()
+
+	pull := func(t *testing.T, expect Status) {
+		t.Helper()
+		resp, err, ok := next()
+		if !ok {
+			t.Fatal("iterator stopped unexpectedly")
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Status != expect {
+			t.Fatalf("got status %v, expected %v", resp.Status, expect)
+		}
+	}
+
+	// First status is delivered immediately.
+	pull(t, StatusServing)
+
+	// Status transitions propagate through the iterator.
+	checker.SetStatus(userFQN, StatusNotServing)
+	pull(t, StatusNotServing)
+
+	checker.SetStatus(userFQN, StatusServing)
+	pull(t, StatusServing)
+
+	// Stopping cancels the stream; the iterator drains.
+	stop()
+	for {
+		_, _, ok := next()
+		if !ok {
+			break
+		}
+	}
+}
+
+func TestClient_Watch_unknownService(t *testing.T) {
+	t.Parallel()
+	checker := NewStaticChecker()
+	mux := http.NewServeMux()
+	mux.Handle(NewHandler(checker))
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.Client(), server.URL, connect.WithGRPC())
+
+	watchIter, stop := client.Watch(t.Context(), &CheckRequest{Service: "unknown.Service"})
+	defer stop()
+	for resp, err := range watchIter {
+		if err == nil {
+			t.Fatalf("expected error, got response: %v", resp)
+		}
+		var connectErr *connect.Error
+		if !errors.As(err, &connectErr) {
+			t.Fatalf("got %v (%T), expected a *connect.Error", err, err)
+		}
+		if code := connectErr.Code(); code != connect.CodeNotFound {
+			t.Fatalf("got code %v, expected CodeNotFound", code)
+		}
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -15,8 +15,8 @@
 package grpchealth
 
 import (
+	"context"
 	"errors"
-	"iter"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -90,44 +90,37 @@ func TestClient_Watch(t *testing.T) {
 
 	client := NewClient(server.Client(), server.URL, connect.WithGRPC())
 
-	// Use iter.Pull2 to step through the Watch iterator, so we can
-	// interleave SetStatus calls between receives.
-	watchIter, stop := client.Watch(t.Context(), &CheckRequest{Service: userFQN})
-	defer stop()
-	next, pullStop := iter.Pull2(watchIter)
-	defer pullStop()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	events := client.Watch(ctx, &CheckRequest{Service: userFQN})
 
-	pull := func(t *testing.T, expect Status) {
+	recv := func(t *testing.T, expect Status) {
 		t.Helper()
-		resp, err, ok := next()
+		event, ok := <-events
 		if !ok {
-			t.Fatal("iterator stopped unexpectedly")
+			t.Fatal("channel closed unexpectedly")
 		}
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		if event.Err != nil {
+			t.Fatalf("unexpected error: %v", event.Err)
 		}
-		if resp.Status != expect {
-			t.Fatalf("got status %v, expected %v", resp.Status, expect)
+		if event.Response.Status != expect {
+			t.Fatalf("got status %v, expected %v", event.Response.Status, expect)
 		}
 	}
 
 	// First status is delivered immediately.
-	pull(t, StatusServing)
+	recv(t, StatusServing)
 
-	// Status transitions propagate through the iterator.
+	// Status transitions propagate through the channel.
 	checker.SetStatus(userFQN, StatusNotServing)
-	pull(t, StatusNotServing)
+	recv(t, StatusNotServing)
 
 	checker.SetStatus(userFQN, StatusServing)
-	pull(t, StatusServing)
+	recv(t, StatusServing)
 
-	// Stopping cancels the stream; the iterator drains.
-	stop()
-	for {
-		_, _, ok := next()
-		if !ok {
-			break
-		}
+	// Canceling the context closes the channel.
+	cancel()
+	for range events { //nolint:revive // Drain until the channel closes.
 	}
 }
 
@@ -143,18 +136,23 @@ func TestClient_Watch_unknownService(t *testing.T) {
 
 	client := NewClient(server.Client(), server.URL, connect.WithGRPC())
 
-	watchIter, stop := client.Watch(t.Context(), &CheckRequest{Service: "unknown.Service"})
-	defer stop()
-	for resp, err := range watchIter {
-		if err == nil {
-			t.Fatalf("expected error, got response: %v", resp)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	gotErr := false
+	for event := range client.Watch(ctx, &CheckRequest{Service: "unknown.Service"}) {
+		if event.Err == nil {
+			t.Fatalf("expected error, got response: %v", event.Response)
 		}
 		var connectErr *connect.Error
-		if !errors.As(err, &connectErr) {
-			t.Fatalf("got %v (%T), expected a *connect.Error", err, err)
+		if !errors.As(event.Err, &connectErr) {
+			t.Fatalf("got %v (%T), expected a *connect.Error", event.Err, event.Err)
 		}
 		if code := connectErr.Code(); code != connect.CodeNotFound {
 			t.Fatalf("got code %v, expected CodeNotFound", code)
 		}
+		gotErr = true
+	}
+	if !gotErr {
+		t.Fatal("channel closed without delivering an error event")
 	}
 }


### PR DESCRIPTION
Add a `Client` type with `Check` and `Watch` methods that wrap the internal generated protobuf types. Callers use only the library's own `CheckRequest`, `CheckResponse`, and `Status` types, so there is no proto registration conflict when the same process also imports `google.golang.org/grpc/health/grpc_health_v1`. Watch returns an `iter.Seq2` iterator instead of a bespoke stream wrapper or channel to avoid a custom struct or goroutine.

Closes https://github.com/connectrpc/grpchealth-go/issues/72